### PR TITLE
Fixes for Terraform updates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    brightbox = {
+      source = "brightbox/brightbox"
+      version = "~> 3.0"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,4 +8,5 @@ output "db_ip_address" {
 
 output "db_admin_account_password" {
   value = brightbox_database_server.db.admin_password
+  sensitive = true
 }

--- a/provider.tf
+++ b/provider.tf
@@ -4,8 +4,6 @@
 // BRIGHTBOX_PASSWORD
 
 provider "brightbox" {
-  version = "~> 1.0"
-
   username  = var.username
   password  = var.password
   account   = var.account


### PR DESCRIPTION
The provider and version have changed since this example was first
created. Required providers and their versions are declared outside of
the provider code now.

The Brightbox provider has now moved from a `hashicorp` prefix to the
registry under `brightbox/brightbox`.

A `sensitive` setting is required for the DB password output to avoid an
error during planning/applying so the field is protected.